### PR TITLE
Hide train ends sticking out past lines at terminus stations

### DIFF
--- a/server/data/line1.js
+++ b/server/data/line1.js
@@ -1,396 +1,397 @@
 export const line_1 = {
     line_1_finch_vmc: {
-        name: "Finch",
-        y: 0,
-        transition: {
-          duration: 0,
-          ease: "easeInOut",
-        },
+      name: "Finch",
+      y: 0,
+      y1: 419,
+      transition: {
+        duration: 0,
+        ease: "easeInOut",
       },
+    },
     line_1_north_york_centre_vmc: {
       name: "North York Centre",
       y: 75,
+      y1: 399,
       transition: {
         duration: 5,
         ease: "easeInOut",
       },
     },
     line_1_sheppard_yonge_vmc: {
-        name: "Sheppard Yonge",
-        y: 150,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+      name: "Sheppard Yonge",
+      y: 150,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_york_mills_vmc: {
-        name: "York Mills",
-        y: 300,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_york_mills_vmc: {
+      name: "York Mills",
+      y: 300,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_lawrence_vmc: {
-        name: "Lawrence",
-        y: 450,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_lawrence_vmc: {
+      name: "Lawrence",
+      y: 450,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_eglinton_vmc: {
-        name: "Eglinton",
-        y: 600,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_eglinton_vmc: {
+      name: "Eglinton",
+      y: 600,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_davisville_vmc: {
-        name: "Davisville",
-        y: 675,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_davisville_vmc: {
+      name: "Davisville",
+      y: 675,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_st_clair_vmc: {
-        name: "St. Clair",
-        y: 750,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_st_clair_vmc: {
+      name: "St. Clair",
+      y: 750,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_summerhill_vmc: {
-        name: "Summerhill",
-        y: 825,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_summerhill_vmc: {
+      name: "Summerhill",
+      y: 825,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_rosedale_vmc: {
-        name: "Rosedale",
-        y: 900,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_rosedale_vmc: {
+      name: "Rosedale",
+      y: 900,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_bloor_yonge_vmc: {
-        name: "Summerhill",
-        y: 975,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_bloor_yonge_vmc: {
+      name: "Summerhill",
+      y: 975,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_wellesley_vmc: {
-        name: "Wellesley",
-        y: 1050,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_wellesley_vmc: {
+      name: "Wellesley",
+      y: 1050,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_college_vmc: {
-        name: "College",
-        y: 1125,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_college_vmc: {
+      name: "College",
+      y: 1125,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_dundas_vmc: {
-        name: "Dundas",
-        y: 1200,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_dundas_vmc: {
+      name: "Dundas",
+      y: 1200,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_queen_vmc: {
-        name: "Queen",
-        y: 1275,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_queen_vmc: {
+      name: "Queen",
+      y: 1275,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_king_vmc: {
-        name: "King",
-        y: 1350,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_king_vmc: {
+      name: "King",
+      y: 1350,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_union_vmc: {
-        name: "Union",
-        rotate: 90,
-        originX: "2268px",
-        originY: "419px",
-        y: 1350,
-        x:0,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_union_vmc: {
+      name: "Union",
+      rotate: 90,
+      originX: "2268px",
+      originY: "419px",
+      y: 1350,
+      x:0,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_st_andrews_vmc: {
-        name: "St. Andrews",
-        rotate: 180,
-        originX: "2268px",
-        originY: "419px",
-        y: 1350,
-        x:0,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_st_andrews_vmc: {
+      name: "St. Andrews",
+      rotate: 180,
+      originX: "2268px",
+      originY: "419px",
+      y: 1350,
+      x:0,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_osgoode_vmc: {
-        name: "Osgoode",
-        rotate: 180,
-        originX: "2268px",
-        originY: "419px",
-        y: 1275,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_osgoode_vmc: {
+      name: "Osgoode",
+      rotate: 180,
+      originX: "2268px",
+      originY: "419px",
+      y: 1275,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_st_patrick_vmc: {
-        name: "St. Patrick",
-        rotate: 180,
-        originX: "2268px",
-        originY: "419px",
-        y: 1200,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_st_patrick_vmc: {
+      name: "St. Patrick",
+      rotate: 180,
+      originX: "2268px",
+      originY: "419px",
+      y: 1200,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_queens_park_vmc: {
-        name: "Queen's Park",
-        rotate: 180,
-        originX: "2268px",
-        originY: "419px",
-        y: 1125,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_queens_park_vmc: {
+      name: "Queen's Park",
+      rotate: 180,
+      originX: "2268px",
+      originY: "419px",
+      y: 1125,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_museum_vmc: {
-        name: "Museum",
-        rotate: 180,
-        originX: "2268px",
-        originY: "419px",
-        y: 1050,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_museum_vmc: {
+      name: "Museum",
+      rotate: 180,
+      originX: "2268px",
+      originY: "419px",
+      y: 1050,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_st_george_vmc: {
-        name: "St. George",
-        rotate: 180,
-        originX: "2268px",
-        originY: "419px",
-        y: 975,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_st_george_vmc: {
+      name: "St. George",
+      rotate: 180,
+      originX: "2268px",
+      originY: "419px",
+      y: 975,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_museum_fin: {
-        name: "Museum",
-        rotate: 180,
-        originX: "2268px",
-        originY: "419px",
-        y: 1050,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_museum_fin: {
+      name: "Museum",
+      rotate: 180,
+      originX: "2268px",
+      originY: "419px",
+      y: 1050,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_queens_park_fin: {
-        name: "Queen's Park",
-        rotate: 180,
-        originX: "2268px",
-        originY: "419px",
-        y: 1125,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_queens_park_fin: {
+      name: "Queen's Park",
+      rotate: 180,
+      originX: "2268px",
+      originY: "419px",
+      y: 1125,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_st_patrick_fin: {
-        name: "St. Patrick",
-        rotate: 180,
-        originX: "2268px",
-        originY: "419px",
-        y: 1200,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_st_patrick_fin: {
+      name: "St. Patrick",
+      rotate: 180,
+      originX: "2268px",
+      originY: "419px",
+      y: 1200,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_osgoode_fin: {
-        name: "Osgoode",
-        rotate: 180,
-        originX: "2268px",
-        originY: "419px",
-        y: 1275,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_osgoode_fin: {
+      name: "Osgoode",
+      rotate: 180,
+      originX: "2268px",
+      originY: "419px",
+      y: 1275,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_st_andrews_fin: {
-        name: "St. Andrews",
-        rotate: 180,
-        originX: "2268px",
-        originY: "419px",
-        y: 1350,
-        x:0,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_st_andrews_fin: {
+      name: "St. Andrews",
+      rotate: 180,
+      originX: "2268px",
+      originY: "419px",
+      y: 1350,
+      x:0,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_union_fin: {
-        name: "Union",
-        rotate: 90,
-        originX: "2268px",
-        originY: "419px",
-        y: 1350,
-        x:0,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_union_fin: {
+      name: "Union",
+      rotate: 90,
+      originX: "2268px",
+      originY: "419px",
+      y: 1350,
+      x:0,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-
-      line_1_king_fin: {
-        name: "King",
-        y: 1350,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_king_fin: {
+      name: "King",
+      y: 1350,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_queen_fin: {
-        name: "Queen",
-        y: 1275,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_queen_fin: {
+      name: "Queen",
+      y: 1275,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_dundas_fin: {
-        name: "Dundas",
-        y: 1200,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_dundas_fin: {
+      name: "Dundas",
+      y: 1200,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_college_fin: {
-        name: "College",
-        y: 1125,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_college_fin: {
+      name: "College",
+      y: 1125,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_wellesley_fin: {
-        name: "Wellesley",
-        y: 1050,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_wellesley_fin: {
+      name: "Wellesley",
+      y: 1050,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_bloor_yonge_fin: {
-        name: "Summerhill",
-        y: 975,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_bloor_yonge_fin: {
+      name: "Summerhill",
+      y: 975,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_rosedale_fin: {
-        name: "Rosedale",
-        y: 900,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_rosedale_fin: {
+      name: "Rosedale",
+      y: 900,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_summerhill_fin: {
-        name: "Summerhill",
-        y: 825,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_summerhill_fin: {
+      name: "Summerhill",
+      y: 825,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_st_clair_fin: {
-        name: "St. Clair",
-        y: 750,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_st_clair_fin: {
+      name: "St. Clair",
+      y: 750,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_davisville_fin: {
-        name: "Davisville",
-        y: 675,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_davisville_fin: {
+      name: "Davisville",
+      y: 675,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_eglinton_fin: {
-        name: "Eglinton",
-        y: 600,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_eglinton_fin: {
+      name: "Eglinton",
+      y: 600,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_lawrence_fin: {
-        name: "Lawrence",
-        y: 450,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_lawrence_fin: {
+      name: "Lawrence",
+      y: 450,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_york_mills_fin: {
-        name: "York Mills",
-        y: 300,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_york_mills_fin: {
+      name: "York Mills",
+      y: 300,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      line_1_sheppard_yonge_fin: {
-        name: "Sheppard Yonge",
-        y: 150,
-        transition: {
-          duration: 5,
-          ease: "easeInOut",
-        },
+    },
+    line_1_sheppard_yonge_fin: {
+      name: "Sheppard Yonge",
+      y: 150,
+      transition: {
+        duration: 5,
+        ease: "easeInOut",
       },
-      
+    },
     line_1_north_york_centre_fin: {
       name: "North York Centre",
       y: 75,
+      y1: 399,
       transition: {
         duration: 5,
         ease: "easeInOut",
@@ -399,14 +400,11 @@ export const line_1 = {
     line_1_finch_fin: {
       name: "Finch",
       y: 0,
+      y1: 419,
       transition: {
+        y1: { duration: 2.5, delay: 2.5 },
         duration: 5,
         ease: "easeInOut",
       },
-    },
-      
-      
-      
-      
-      
+    },  
 }

--- a/server/data/line4.js
+++ b/server/data/line4.js
@@ -2,22 +2,26 @@ export const line_4 = {
     line_4_sheppard_east: {
       name: "Sheppard-East",
       x: 0,
+      x1: 2345,
       transition: {
+        x1: { duration: 1, delay: 4 },
         duration: 5,
         ease: "easeInOut",
       },
     },
     line_4_bayview_east: {
       name: "Bayview",
-      x: 222, 
+      x: 224,
+      x1: 2325,
       transition: {
+        x1: { duration: 1 },
         duration: 5,
         ease: "easeInOut",
       },
     },
     line_4_bessarion_east: {
       name: "Bessarion",
-      x: 333, 
+      x: 336, 
       transition: {
         duration: 3,
         ease: "easeInOut",
@@ -25,7 +29,8 @@ export const line_4 = {
     },
     line_4_leslie_east: {
       name: "Leslie",
-      x: 452, 
+      x: 449,
+      x2: 2365,
       transition: {
         duration: 3,
         ease: "easeInOut",
@@ -33,15 +38,18 @@ export const line_4 = {
     },
     line_4_don_mills: {
       name: "Don Mills",
-      x: 526, 
+      x: 523,
+      x2: 2345,
       transition: {
+        x2: { duration: 1.5, delay: 1.5 },
         duration: 3,
         ease: "easeInOut",
       },
     },
     line_4_leslie_west: {
       name: "Leslie",
-      x: 452, 
+      x: 449,
+      x2: 2365,
       transition: {
         duration: 3,
         ease: "easeInOut",
@@ -49,7 +57,7 @@ export const line_4 = {
     },
     line_4_bessarion_west: {
       name: "Bessarion",
-      x: 333, 
+      x: 336, 
       transition: {
         duration: 3,
         ease: "easeInOut",
@@ -57,7 +65,7 @@ export const line_4 = {
     },
     line_4_bayview_west: {
       name: "Bayview",
-      x: 222, 
+      x: 224, 
       transition: {
         duration: 3,
         ease: "easeInOut",


### PR DESCRIPTION
Adds to framer motion variants for terminus stations to shorten the length of the svg line. Also indent changes for line1 data file for slightly more consistency